### PR TITLE
ide only connect to nb on demand

### DIFF
--- a/netsblox/app.py
+++ b/netsblox/app.py
@@ -131,6 +131,12 @@ main_menu = None
 content = None
 drag_widget = None
 
+def get_nb():
+    global nb
+    if nb is None:
+        nb = netsblox.Client()
+    return nb
+
 _print_queue = mproc.Queue(maxsize = 256)
 _print_batchsize = 256
 _print_targets = []
@@ -2243,7 +2249,7 @@ class MainMenu(tk.Menu):
         root.bind_all(f'<{SYS_INFO["mod"]}-equal>', lambda e: do_zoom(1)) # plus without needing shift
         root.bind_all(f'<{SYS_INFO["mod"]}-minus>', lambda e: do_zoom(-1))
 
-        self.room_manager = rooms.EditorRoomManager(client = nb)
+        self.room_manager = rooms.EditorRoomManager(get_client = get_nb)
 
         self.roles_dropdown = tk.Menu(self, **MENU_STYLE)
         self.add_cascade(label = 'Roles', menu = self.roles_dropdown)
@@ -2825,7 +2831,7 @@ def log(msg) -> None:
         _logger_instance.log(msg)
 
 def main():
-    global nb, root, main_menu, content, drag_widget, _logger_instance
+    global root, main_menu, content, drag_widget, _logger_instance
 
     Sound.init()
 
@@ -2835,8 +2841,6 @@ def main():
     args = parser.parse_args()
 
     _logger_instance = Logger(target = args.log_to)
-
-    nb = netsblox.Client()
 
     root = tk.Tk()
     root.geometry('1200x600')

--- a/netsblox/rooms.py
+++ b/netsblox/rooms.py
@@ -107,8 +107,8 @@ class RcRoomHandle:
         self.__cached = None
 
 class EditorRoomManager:
-    def __init__(self, *, client: Any):
-        self.__client = client
+    def __init__(self, *, get_client: Any):
+        self.__get_client = get_client
         self.__handle = None
         self.__room_name = None
         self.__room_password = None
@@ -117,7 +117,7 @@ class EditorRoomManager:
         if self.__handle is not None:
             self.__handle.destroy()
 
-        self.__client = None
+        self.__get_client = None
         self.__handle = None
         self.__room_name = None
         self.__room_password = None
@@ -137,7 +137,7 @@ class EditorRoomManager:
 
     def create_room(self, password: Optional[str] = None) -> None:
         room_name = randomname.get_name()
-        new_handle = RcRoomHandle(self.__client, format_room_id(room_name), password, mode = 'create')
+        new_handle = RcRoomHandle(self.__get_client(), format_room_id(room_name), password, mode = 'create')
 
         if self.__handle is not None:
             self.__handle.destroy()
@@ -147,7 +147,7 @@ class EditorRoomManager:
         self.__room_password = password
 
     def join_room(self, room_name: str, password: Optional[str] = None) -> None:
-        new_handle = RcRoomHandle(self.__client, format_room_id(room_name), password, mode = 'join')
+        new_handle = RcRoomHandle(self.__get_client(), format_room_id(room_name), password, mode = 'join')
 
         if self.__handle is not None:
             self.__handle.destroy()


### PR DESCRIPTION
Closes #3.

NetsBlox connection switched to Meyer's singleton, so only constructed on-demand. Now the IDE successfully opens even when NetsBlox cannot be accessed, and shows future conn errors as error popups rather than only being in the terminal.