### PR TITLE
make service/rpc positional-only for call

### DIFF
--- a/template/client-class.py
+++ b/template/client-class.py
@@ -310,7 +310,7 @@ $service_instances
             return f
         return wrapper
 
-    def call(self, service: str, rpc: str, **kwargs) -> Any:
+    def call(self, service: str, rpc: str, /, **kwargs) -> Any:
         '''
         Directly calls the specified NetsBlox RPC based on its name.
         This is needed to access unofficial or dynamically-generated (like create-a-service) services.


### PR DESCRIPTION
Closes #7 by making service/rpc positional-only for generic call, so keyword args are always rpc inputs.